### PR TITLE
Fixed path issue with newest Homebrew

### DIFF
--- a/Formula/encrypto-cli.rb
+++ b/Formula/encrypto-cli.rb
@@ -7,7 +7,7 @@ class EncryptoCli < Formula
   bottle :unneeded
 
   def install
-    prefix.install "encrypto-cli/encrypto-cli.bundle" => "encrypto-cli.bundle"
+    prefix.install "encrypto-cli.bundle" => "encrypto-cli.bundle"
     bin.install_symlink prefix/"encrypto-cli.bundle/Contents/MacOS/encrypto-cli"
   end
 


### PR DESCRIPTION
Fixed formula for Encrypto-cli to ensure compatibility with current Homebrew versions.