### PR TITLE
Remove obsolete `bottle :unneeded`

### DIFF
--- a/Formula/encrypto-cli.rb
+++ b/Formula/encrypto-cli.rb
@@ -4,8 +4,6 @@ class EncryptoCli < Formula
   url "https://github.com/MacPaw/homebrew-taps/raw/binaries/encrypto-cli.bundle-0.0.1.zip"
   sha256 "205831200254bf2cb13765ca799b1f1299c01195224af5639aee46aa19c85f3d"
 
-  bottle :unneeded
-
   def install
     prefix.install "encrypto-cli.bundle" => "encrypto-cli.bundle"
     bin.install_symlink prefix/"encrypto-cli.bundle/Contents/MacOS/encrypto-cli"


### PR DESCRIPTION
`bottle :unneeded` is now obsolete.

```sh
$ brew install encrypto-cli
Error: encrypto-cli: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the macpaw/taps tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/macpaw/homebrew-taps/Formula/encrypto-cli.rb:7
```